### PR TITLE
Run in series

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ To run in watch mode, restarting as you change files, add `TEST_WATCH=1` before 
 
 NOTE: Watch mode does not properly rerun client tests if you change only client code. To work around this, you can add or remove whitespace from a server file, and that will trigger both server and client tests to rerun.
 
+### Run in parallel
+
+By default dispatch:mocha will run in series. This is a safety mechanism since running a client test and server test which depend on DB state may have side-effects.
+
+If you design your client and server tests to not share state, then you can run tests faster.
+
+Run in parallel simply by exporting the environment variable `TEST_PARALLEL=1` or `TEST_PARALLEL=true` before running.
+
 ### Run with a different server reporter
 
 The default Mocha reporter for server tests is the "spec" reporter. You can set the `SERVER_TEST_REPORTER` environment variable to change it.

--- a/server.js
+++ b/server.js
@@ -6,6 +6,11 @@ const reporter = process.env.SERVER_TEST_REPORTER || 'spec';
 // If TEST_BROWSER_DRIVER is not set, assume the app has only server tests
 const shouldRunClientTests = !!process.env.TEST_BROWSER_DRIVER;
 
+let shouldRunInParallel = false
+if (process.env.TEST_PARALLEL && (process.env.TEST_PARALLEL === ('true' || 1))) {
+  shouldRunInParallel = true
+}
+
 // pass the current env settings to the client.//
 Meteor.startup(() => {
   Meteor.settings.public = Meteor.settings.public || {};
@@ -70,15 +75,7 @@ function exitIfDone(type, failures) {
   }
 }
 
-// Before Meteor calls the `start` function, app tests will be parsed and loaded by Mocha
-function start() {
-  // Run the server tests
-  if (shouldRunClientTests) {
-    printHeader('SERVER');
-  } else {
-    console.log('SKIPPING CLIENT TESTS BECAUSE TEST_BROWSER_DRIVER ENVIRONMENT VARIABLE IS NOT SET');
-  }
-
+function serverTests(cb){
   // We need to set the reporter when the tests actually run to ensure no conflicts with
   // other test driver packages that may be added to the app but are not actually being
   // used on this run.
@@ -86,23 +83,62 @@ function start() {
 
   mochaInstance.run((failureCount) => {
     exitIfDone('server', failureCount);
+    if (cb) { cb(); }
   });
 
-  // Simultaneously start headless browser to run the client tests
-  if (shouldRunClientTests) {
-    startBrowser({
-      stdout(data) {
-        clientLogBuffer(data.toString());
-      },
-      stderr(data) {
-        clientLogBuffer(data.toString());
-      },
-      done(failureCount) {
-        exitIfDone('client', failureCount);
-      },
-    });
-  } else {
-    exitIfDone('client', 0);
+}
+
+function clientTests(cb){
+  startBrowser({
+    stdout(data) {
+      clientLogBuffer(data.toString());
+    },
+    stderr(data) {
+      clientLogBuffer(data.toString());
+    },
+    done(failureCount) {
+      exitIfDone('client', failureCount);
+      if (cb) { cb(); }
+    },
+  });
+}
+
+// Before Meteor calls the `start` function, app tests will be parsed and loaded by Mocha
+function start() {
+  if (!shouldRunClientTests) {
+    console.log('SKIPPING CLIENT TESTS BECAUSE TEST_BROWSER_DRIVER ENVIRONMENT VARIABLE IS NOT SET');
+  }
+
+  printHeader('SERVER');
+
+
+  // Run in PARALLEL or SERIES
+  // run in series is a better default IMHO since it avoids db and state conflicts for newbs
+  // if you want parallel you will know these risks
+  if (shouldRunInParallel){
+    console.log('Warning: Running in parallel can cause side-effects from state/db sharing');
+
+    serverTests()
+    // Simultaneously start headless browser to run the client tests
+    if (shouldRunClientTests) {
+      // printHeader('CLIENT');
+      clientTests();
+    } else {
+      exitIfDone('client', 0);
+    }//
+
+  } else { // run in series by default
+
+    printHeader('SERVER');
+    serverTests(function(){
+      // Simultaneously start headless browser to run the client tests
+      if (shouldRunClientTests) {
+        printHeader('CLIENT');
+        clientTests();
+      } else {
+        exitIfDone('client', 0);
+      }
+    })
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -96,6 +96,13 @@ function serverTests(cb){
 }
 
 function clientTests(cb){
+
+  if (!shouldRunClientTests) {
+    console.log('SKIPPING CLIENT TESTS BECAUSE TEST_BROWSER_DRIVER ENVIRONMENT VARIABLE IS NOT SET');
+    exitIfDone('client', 0);
+    return;
+  }
+
   printHeader('CLIENT');
 
   startBrowser({
@@ -114,32 +121,20 @@ function clientTests(cb){
 
 // Before Meteor calls the `start` function, app tests will be parsed and loaded by Mocha
 function start() {
-  if (!shouldRunClientTests) {
-    console.log('SKIPPING CLIENT TESTS BECAUSE TEST_BROWSER_DRIVER ENVIRONMENT VARIABLE IS NOT SET');
-  }
 
   // Run in PARALLEL or SERIES
   // run in series is a better default IMHO since it avoids db and state conflicts for newbs
   // if you want parallel you will know these risks
   if (shouldRunInParallel){
     console.log('Warning: Running in parallel can cause side-effects from state/db sharing');
+    
+    serverTests();
+    clientTests();
 
-    serverTests()
-    // Simultaneously start headless browser to run the client tests
-    if (shouldRunClientTests) {
-      clientTests();
-    } else {
-      exitIfDone('client', 0);
-    }
   } else { // run in series by default
-    serverTests(function(){
-      // Simultaneously start headless browser to run the client tests
-      if (shouldRunClientTests) {
-        clientTests();
-      } else {
-        exitIfDone('client', 0);
-      }
-    })
+    serverTests(() => {
+      clientTests();
+    });
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const reporter = process.env.SERVER_TEST_REPORTER || 'spec';
 // If TEST_BROWSER_DRIVER is not set, assume the app has only server tests
 const shouldRunClientTests = !!process.env.TEST_BROWSER_DRIVER;
 
-// pass the current env settings to the client.
+// pass the current env settings to the client.//
 Meteor.startup(() => {
   Meteor.settings.public = Meteor.settings.public || {};
   Meteor.settings.public.CLIENT_TEST_REPORTER = process.env.CLIENT_TEST_REPORTER;

--- a/server.js
+++ b/server.js
@@ -6,10 +6,7 @@ const reporter = process.env.SERVER_TEST_REPORTER || 'spec';
 // If TEST_BROWSER_DRIVER is not set, assume the app has only server tests
 const shouldRunClientTests = !!process.env.TEST_BROWSER_DRIVER;
 
-let shouldRunInParallel = false
-if (process.env.TEST_PARALLEL && (process.env.TEST_PARALLEL === ('true' || 1))) {
-  shouldRunInParallel = true
-}
+const shouldRunInParallel = !!process.env.TEST_PARALLEL;
 
 // pass the current env settings to the client.//
 Meteor.startup(() => {


### PR DESCRIPTION
@aldeed here's a proposal to solve running in parallel/series re: https://github.com/DispatchMe/meteor-mocha/issues/6

In readme:

### Run in parallel

By default dispatch:mocha will run in series. This is a safety mechanism since running a client test and server test which depend on DB state may have side-effects.

If you design your client and server tests to not share state, then you can run tests faster.

Run in parallel simply by exporting the environment variable `TEST_PARALLEL=1` or `TEST_PARALLEL=true` before running.