### PR TITLE
Merge with mocha-browser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+We welcome contributions. Before submitting a pull request, please check the following:
+
+(1) Branch from and submit back to the `master` branch
+(2) If adding or changing a feature, add documentation to README.md
+(3) Squash your changes down to one commit.
+(4) If your PR becomes unmergeable due to other merged changes, rebase it on the latest `master` branch
+(5) Run eslint and fix any errors:
+
+```bash
+$ npm i
+$ npm run lint
+```

--- a/README.md
+++ b/README.md
@@ -10,15 +10,56 @@ In a Meteor 1.3+ app directory:
 meteor add dispatch:mocha
 ```
 
-## Run app unit tests
+## Run app tests
 
-If you do not have any tests in client code:
+To run unit tests one time and exit:
 
 ```bash
 meteor test --once --driver-package dispatch:mocha
 ```
 
-If you do have client tests, you'll need to specify which browser to use and install the necessary NPM packages. To do this, set the `TEST_BROWSER_DRIVER` environment variable. There are currently 3 supported browsers:
+To run full-app tests one time and exit:
+
+```bash
+meteor test --once --full-app --driver-package dispatch:mocha
+```
+
+To run in watch mode, restarting as you change files, add `TEST_WATCH=1` before your test command and remove the `--once` flag. For example:
+
+```bash
+TEST_WATCH=1 meteor test --driver-package dispatch:mocha
+```
+
+> NOTE: Watch mode does not properly rerun client tests if you change only client code. To work around this, you can add or remove whitespace from a server file, and that will trigger both server and client tests to rerun.
+
+If you have client tests, you can either open any browser to run them, or install a browser driver to run them headless.
+
+### Run client tests in any browser manually
+
+Load `http://localhost:3000` in a browser to run your client tests and see the results. This only works well in watch mode because otherwise the server will likely shut down before you finish running the client tests.
+
+The test results are reported in a div with ID `mocha`. If you run with the `--full-app` flag, this will likely be overlaid weirdly on top of your app, so you should add CSS to your app in order to be able to see both. For example, this will put the test results in a sidebar with resizeable width:
+
+```css
+div#mocha {
+  background: white;
+  border-right: 2px solid black;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  overflow: auto;
+  padding: 1rem;
+  position: fixed;
+  resize: horizontal;
+  top: 0;
+  width: 20px;
+  z-index: 1000;
+}
+```
+
+### Run client tests headless
+
+You'll need to specify which headless browser to use and install the necessary NPM packages. To do this, set the `TEST_BROWSER_DRIVER` environment variable. There are currently 3 supported browsers:
 
 **Chrome**
 
@@ -45,30 +86,21 @@ $ npm i --save-dev phantomjs-prebuilt
 $ TEST_BROWSER_DRIVER=phantomjs meteor test --once --driver-package dispatch:mocha
 ```
 
-### Run in watch mode
-
-To run in watch mode, restarting as you change files, add `TEST_WATCH=1` before your test command and remove the `--once` flag.
-
-NOTE: Watch mode does not properly rerun client tests if you change only client code. To work around this, you can add or remove whitespace from a server file, and that will trigger both server and client tests to rerun.
-
-
-### Run only server or client tests
+### Run only server or only client tests
 
 By default both server and client tests run. To disable server tests: `TEST_SERVER=0`. Likewise for client: `TEST_CLIENT=0`
 
-### Run tests inclusively (grep), and exclusively (invert)
+### Run tests inclusively (grep) or exclusively (invert)
 
 To run all tests with names that match a pattern, add the environment variable `MOCHA_GREP=your_string`. This will apply to both client and server tests.
 
-To exclude any tests, you must use the grep option above plus `MOCHA_INVERT=1`. For example, to exclude tests named 'TODO:' ( which you may want to exclude from your continuous integration workflow) you would pass at runtime `MOCHA_GREP=your_string MOCHA_INVERT=1`
+To exclude any tests, you must use the grep option above plus `MOCHA_INVERT=1`. For example, to exclude tests named 'TODO:' (which you may want to exclude from your continuous integration workflow) you would pass at runtime `MOCHA_GREP=your_string MOCHA_INVERT=1`
 
 ### Run in parallel
 
-By default dispatch:mocha will run in series. This is a safety mechanism since running a client test and server test which depend on DB state may have side-effects.
+By default dispatch:mocha will run in series. This is a safety mechanism since running a client test and server test which depend on DB state may have side effects.
 
-If you design your client and server tests to not share state, then you can run tests faster.
-
-Run in parallel by exporting the environment variable `TEST_PARALLEL=1` before running.
+If you design your client and server tests to not share state, then you can run tests faster. Run in parallel by exporting the environment variable `TEST_PARALLEL=1` before running.
 
 ### Run with a different server reporter
 
@@ -91,7 +123,7 @@ $ SERVER_TEST_REPORTER=xunit XUNIT_FILE=$PWD/unit.xml meteor test --once --drive
 The default Mocha reporter for client tests is the "spec" reporter. You can set the `CLIENT_TEST_REPORTER` environment variable to change it.
 
 ```bash
-$ CLIENT_TEST_REPORTER="tap" meteor test --once --driver-package dispatch:mocha-phantomjs
+$ CLIENT_TEST_REPORTER="tap" meteor test --once --driver-package dispatch:mocha
 ```
 
 Because of the differences between client and server code, not all reporters will work as client reporters. "spec" and "tap" are confirmed to work.
@@ -109,18 +141,11 @@ A good best practice is to define these commands as run scripts in your app's `p
   "test-app-phantom": "TEST_BROWSER_DRIVER=phantomjs meteor test --full-app --once --driver-package dispatch:mocha",
   "test-watch": "TEST_BROWSER_DRIVER=chrome TEST_WATCH=1 meteor test --driver-package dispatch:mocha",
   "test-app-watch": "TEST_BROWSER_DRIVER=chrome TEST_WATCH=1 meteor test --full-app --driver-package dispatch:mocha",
+  "test-watch-browser": "TEST_WATCH=1 meteor test --driver-package dispatch:mocha",
+  "test-app-watch-browser": "TEST_WATCH=1 meteor test --full-app --driver-package dispatch:mocha",
   "lint": "eslint .",
   "start": "meteor run"
 }
 ```
 
 And then run `npm run test-chrome`, etc.
-
-## Contributing
-
-Run eslint:
-
-```bash
-$ npm i
-$ npm run lint
-```

--- a/client.js
+++ b/client.js
@@ -1,5 +1,5 @@
 import { mocha } from 'meteor/practicalmeteor:mocha-core';
-
+import prepForHTMLReporter from './prepForHTMLReporter';
 import './browser-shim';
 
 // Run the client tests. Meteor calls the `runTests` function exported by
@@ -16,16 +16,25 @@ function runTests() {
   const { clientReporter, grep, invert, reporter } = mochaOptions || {};
   if (grep) mocha.grep(grep);
   if (invert) mocha.options.invert = invert;
-  mocha.reporter(clientReporter || reporter);
 
-  // These `window` properties are all used by the client testing script in the
-  // browser-tests package to know what is happening.
-  window.testsAreRunning = true;
-  mocha.run((failures) => {
-    window.testsAreRunning = false;
-    window.testFailures = failures;
-    window.testsDone = true;
-  });
+  if (runnerOptions.browserDriver) {
+    mocha.reporter(clientReporter || reporter);
+
+    // These `window` properties are all used by the client testing script in the
+    // browser-tests package to know what is happening.
+    window.testsAreRunning = true;
+    mocha.run((failures) => {
+      window.testsAreRunning = false;
+      window.testFailures = failures;
+      window.testsDone = true;
+    });
+  } else {
+    // If we're not running client tests automatically in a headless browser, then we
+    // probably are going to want to see an HTML reporter when we load the page.
+    prepForHTMLReporter(mocha);
+    mocha.reporter('html');
+    mocha.run();
+  }
 }
 
 export { runTests };

--- a/prepForHTMLReporter.js
+++ b/prepForHTMLReporter.js
@@ -1,0 +1,12 @@
+export default function prepForHTMLReporter(mocha) {
+  // Add the CSS from CDN
+  const link = document.createElement('link');
+  link.setAttribute('rel', 'stylesheet');
+  link.setAttribute('href', 'https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css');
+  document.head.appendChild(link);
+
+  // Add the div#mocha in which test results HTML will be placed
+  const div = document.createElement('div');
+  div.setAttribute('id', 'mocha');
+  document.body.appendChild(div);
+}

--- a/server.js
+++ b/server.js
@@ -54,11 +54,12 @@ function exitIfDone(type, failures) {
   }
 
   if (callCount === 2) {
-    if (runnerOptions.runClient) {
+    // We only need to show this final summary if we ran both kinds of tests in the same console
+    if (runnerOptions.runServer && runnerOptions.runClient && runnerOptions.browserDriver) {
       console.log('All tests finished!\n');
       console.log('--------------------------------');
-      if (runnerOptions.runServer) console.log(`SERVER FAILURES: ${serverFailures}`);
-      if (runnerOptions.runClient) console.log(`CLIENT FAILURES: ${clientFailures}`);
+      console.log(`SERVER FAILURES: ${serverFailures}`);
+      console.log(`CLIENT FAILURES: ${clientFailures}`);
       console.log('--------------------------------');
     }
 
@@ -106,7 +107,10 @@ function clientTests() {
   }
 
   if (!runnerOptions.browserDriver) {
-    console.log('SKIPPING CLIENT TESTS BECAUSE TEST_BROWSER_DRIVER ENVIRONMENT VARIABLE IS NOT SET');
+    console.log(
+      'Load the app in a browser to run client tests, or set the TEST_BROWSER_DRIVER environment variable. ' +
+      'See https://github.com/DispatchMe/meteor-mocha/blob/master/README.md#run-app-tests'
+    );
     exitIfDone('client', 0);
     return;
   }


### PR DESCRIPTION
This merges in the code from https://github.com/DispatchMe/meteor-mocha-browser and makes that pkg obsolete.

It will assume you're running tests manually in some browser if you do not set `TEST_BROWSER_DRIVER` and you do not set `TEST_CLIENT=0`