### PR TITLE
fix: await Meteor.startup() queue before running tests

### DIFF
--- a/package/server.js
+++ b/package/server.js
@@ -204,7 +204,14 @@ function clientTests() {
 }
 
 // Before Meteor calls the `start` function, app tests will be parsed and loaded by Mocha
-function start() {
+async function start() {
+  // Wait for all Meteor.startup() callbacks (including async ones) to complete.
+  // In Meteor 3.x, async startup callbacks and top-level await can cause the
+  // startup queue to still be draining when the test driver's start() is called.
+  // Adding a callback at the end of the queue ensures it runs after all prior
+  // callbacks have finished. See: https://github.com/Meteor-Community-Packages/meteor-mocha/issues/176
+  await new Promise(resolve => Meteor.startup(resolve));
+
   const args = setArgs();
   runnerOptions = args.runnerOptions;
   coverageOptions = args.coverageOptions;

--- a/tests/dummy_app/server/async-startup.tests.js
+++ b/tests/dummy_app/server/async-startup.tests.js
@@ -1,0 +1,21 @@
+/* eslint-env mocha */
+import { Meteor } from 'meteor/meteor';
+import assert from 'assert';
+
+// Simulate async startup work (e.g. ensuring MongoDB indices, initializing
+// collections). Without the fix in server.js, mocha.run() can fire before
+// this callback completes, causing the test below to fail.
+let startupCompleted = false;
+
+Meteor.startup(async () => {
+  await new Promise(resolve => setTimeout(resolve, 50));
+  startupCompleted = true;
+});
+
+describe('async Meteor.startup()', function () {
+  it('should complete before tests run', function () {
+    assert.strictEqual(startupCompleted, true,
+      'Async Meteor.startup() callback did not complete before tests ran. ' +
+      'See https://github.com/Meteor-Community-Packages/meteor-mocha/issues/176');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #176

- In Meteor 3.x, `mocha.run()` can fire before all `Meteor.startup()` callbacks have completed, due to async startup callbacks and top-level `await` (TLA) in the module system
- This causes flaky/failing tests when server initialization depends on async startup work (e.g. ensuring MongoDB indices, initializing collections)
- The fix awaits a `Meteor.startup(resolve)` promise at the start of the `start()` function, ensuring all previously queued startup callbacks (including async ones) have finished before tests begin

### How it works

`Meteor.startup()` runs callbacks in FIFO order. By the time the test driver's `start()` is called, all app code has been loaded and has registered its startup callbacks. Adding one more callback (`resolve`) at the end of the queue guarantees it runs last, after all prior async startup work has drained.

### Change

`package/server.js`: Made `start()` async and added `await new Promise(resolve => Meteor.startup(resolve))` before test execution.

## Test results

Tested with the dummy app on Meteor 3.3.2, server-only (`TEST_CLIENT=0`).

**With the fix** — all 4 tests pass:
```
  async Meteor.startup()
    ✔ should complete before tests run

  server suite
    ✔ passing test
    ✔ passing async test
    ✔ passing callback test

  4 passing (3ms)
```

**Without the fix** — the async startup test fails, confirming the regression test is reliable:
```
  async Meteor.startup()
    1) should complete before tests run

  server suite
    ✔ passing test
    ✔ passing async test
    ✔ passing callback test

  3 passing (4ms)
  1 failing

  1) async Meteor.startup()
       should complete before tests run:
     AssertionError: Async Meteor.startup() callback did not complete
     before tests ran.
```

## Test plan

- [x] Run `meteor test` with async `Meteor.startup()` callbacks — passes with fix, fails without
- [ ] Run `meteor test --full-app` — same behavior
- [ ] Verify `TEST_WATCH=1` (watch mode) still works
- [ ] Verify `TEST_PARALLEL=1` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)